### PR TITLE
[4.x.x] New `enabled` attributte in o-button

### DIFF
--- a/_data/components/button.yml
+++ b/_data/components/button.yml
@@ -26,4 +26,7 @@ attributes: [{
   default: "",
   required: "",
   description: "Icon image"
+},{
+  name: "enabled",
+  description : "Indicates whether or not the button is enabled"
 }]


### PR DESCRIPTION
Updated documentation about the new `enabled` attributte in o-button