### PR TITLE
Docs release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,101 @@
+name: Release Docs
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches:
+      - 8.x.x
+      - 4.x.x
+      - 3.x.x
+
+jobs:
+  build-8x:
+    name: Publish doc 8.x
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ', '), 'release-docs'))
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 8.x.x
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bundler Cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Jekyll
+        uses: helaili/jekyll-action@master
+        with:
+          jekyll_env: deploy
+          target_branch: gh-pages
+          target_path: /
+          keep_history: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-4x:
+    name: Publish doc 4.x
+    runs-on: ubuntu-latest
+    needs: [build-8x]
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ', '), 'release-docs'))
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 4.x.x
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bundler Cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Jekyll
+        uses: helaili/jekyll-action@master
+        with:
+          jekyll_env: deploy
+          target_branch: gh-pages
+          target_path: v4
+          keep_history: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-3x:
+    name: Publish doc 3.x
+    runs-on: ubuntu-latest
+    needs: [build-4x]
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ', '), 'release-docs'))
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 3.x.x
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bundler Cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Jekyll
+        uses: helaili/jekyll-action@master
+        with:
+          jekyll_env: deploy
+          target_branch: gh-pages
+          target_path: v3
+          keep_history: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
Creates a GitHub Action workflow that publishes documentation.
The workflow can be triggered via:
- when merging a PR into 8.x.x, 4.x.x or 3.x.x branches that includes the label `release-docs`
- launching manually