### PR TITLE
New input `gap` in `o-phone-input`

### DIFF
--- a/_data/components/phoneInput.yml
+++ b/_data/components/phoneInput.yml
@@ -12,7 +12,15 @@ attributes: [{
   default : "",
   required : "",
   description : "Specifies the countries code that will appear in the country selection combo, if this input is not present the combo will be filled with a predefined list of countries."
-}]
+},{
+   name: "gap",
+  type: "string",
+  default : "14px",
+  required : "",
+  description : " Specify gap between fields in px",
+  since: "8.8.3"
+}
+]
 
 inheritedOutputs: [{
   component: "FormDataComponent",

--- a/_includes/o-component-single-api.md
+++ b/_includes/o-component-single-api.md
@@ -1,5 +1,5 @@
 
-{% assign inputsColumns = "Name|Description|Default" | split: "|" %}
+{% assign inputsColumns = "Name|Since|Description|Default" | split: "|" %}
 {% assign componentData = include.component %}
 {% if componentData %}
  {% if componentData.title %}
@@ -138,9 +138,11 @@
           {% unless emptyColumns contains columnKey %}
             {% assign columnData = 'o-component-' | append: columnKey %}
             {% assign requiredData = '' %}
-
             {% assign cellValue = commonData[columnKey] %}
             {% if attributeObject[columnKey] != undefined %}
+              {% if attributeObject[columnKey] == 'since' %}
+               {% assign cellValue = attributeObject[columnKey] | default:'-' %}
+              {% endif %}
               {% assign cellValue = attributeObject[columnKey] %}
             {% endif %}
             {% assign cellContent = cellValue | default: '' %}


### PR DESCRIPTION
New input `gap` in `o-phone-input`
New column `Since` in api section